### PR TITLE
Fix docker by adding php-curl for stripe lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
     php7.2-mysql \
     php7.2-xml \
     php7.2-zip \
+    php7.2-curl \
     sudo
 
 RUN curl --silent --show-error https://getcomposer.org/installer | php && \


### PR DESCRIPTION
PHP Stripe required php-curl extension to be installed for composer. So it makes the Docker file could not start due to issue with php-curl for composer install command